### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,28 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/APIReference.md
+- [](&)Documentation/ArchitectureGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/CustomizationAPI.md
+- [](&)Documentation/CustomizationGuide.md
+- [](&)Documentation/DataIntegrationAPI.md
+- [](&)Documentation/DataIntegrationGuide.md
+- [](&)Documentation/DynamicIslandAPI.md
+- [](&)Documentation/DynamicIslandGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/HomeScreenWidgetAPI.md
+- [](&)Documentation/HomeScreenWidgetGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/InstallationGuide.md
+- [](&)Documentation/LiveActivityAPI.md
+- [](&)Documentation/LiveActivityGuide.md
+- [](&)Documentation/LockScreenWidgetAPI.md
+- [](&)Documentation/LockScreenWidgetGuide.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/UsageGuide.md
+- [](&)Documentation/WidgetDevelopmentManagerAPI.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,13 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedWidgetExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicWidgetExample.swift
+- ``Examples/DynamicIslandExamples/DynamicIslandExample.swift
+- ``Examples/HomeScreenWidgetExamples/HomeScreenWidgetExample.swift
+- ``Examples/HomeScreenWidgetExamples/WeatherWidgetExample.swift
+- ``Examples/LiveActivityExamples/FitnessTrackerExample.swift
+- ``Examples/LiveActivityExamples/LiveActivityExample.swift
+- ``Examples/LockScreenWidgetExamples/CalendarWidgetExample.swift
+- ``Examples/LockScreenWidgetExamples/LockScreenWidgetExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.